### PR TITLE
[2024.07.21] feat/#1 signup >> 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/user/controller/UserController.java
+++ b/src/main/java/com/complete/todayspace/domain/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.complete.todayspace.domain.user.controller;
+
+import com.complete.todayspace.domain.user.dto.SignupRequestDto;
+import com.complete.todayspace.domain.user.service.UserService;
+import com.complete.todayspace.global.dto.StatusResponseDto;
+import com.complete.todayspace.global.entity.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/auth/signup")
+    public ResponseEntity<StatusResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+
+        userService.signup(requestDto);
+
+        StatusResponseDto response = new StatusResponseDto(SuccessCode.SIGNUP_CREATE);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/complete/todayspace/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/complete/todayspace/domain/user/dto/SignupRequestDto.java
@@ -1,0 +1,23 @@
+package com.complete.todayspace.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SignupRequestDto {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    @Size(min = 4, max = 20, message = "아이디는 4 ~ 20자 입니다.")
+    @Pattern(regexp = "^[a-z0-9]+$", message = "아이디 형식을 확인해주세요.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 4, max = 20, message = "비밀번호는 4 ~ 20자 입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9!@#$%^&*]+$", message = "비밀번호 형식을 확인해주세요.")
+    private String password;
+
+    private String profileImage;
+
+}

--- a/src/main/java/com/complete/todayspace/domain/user/entity/User.java
+++ b/src/main/java/com/complete/todayspace/domain/user/entity/User.java
@@ -32,8 +32,7 @@ public class User extends AllTimestamp {
     @Enumerated(value = EnumType.STRING)
     private UserState state;
 
-    public User(Long id, String username, String password, String profileImage, UserRole role, UserState state) {
-        this.id = id;
+    public User(String username, String password, String profileImage, UserRole role, UserState state) {
         this.username = username;
         this.password = password;
         this.profileImage = profileImage;

--- a/src/main/java/com/complete/todayspace/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/user/repository/UserRepository.java
@@ -4,4 +4,7 @@ import com.complete.todayspace.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUsername(String username);
+
 }

--- a/src/main/java/com/complete/todayspace/domain/user/service/UserService.java
+++ b/src/main/java/com/complete/todayspace/domain/user/service/UserService.java
@@ -1,0 +1,33 @@
+package com.complete.todayspace.domain.user.service;
+
+import com.complete.todayspace.domain.user.dto.SignupRequestDto;
+import com.complete.todayspace.domain.user.entity.User;
+import com.complete.todayspace.domain.user.entity.UserRole;
+import com.complete.todayspace.domain.user.entity.UserState;
+import com.complete.todayspace.domain.user.repository.UserRepository;
+import com.complete.todayspace.global.exception.CustomException;
+import com.complete.todayspace.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signup(SignupRequestDto requestDto) {
+
+        if (userRepository.existsByUsername(requestDto.getUsername())) {
+            throw new CustomException(ErrorCode.USER_NOT_UNIQUE);
+        }
+
+        String encryptedPassword = passwordEncoder.encode(requestDto.getPassword());
+        User user = new User(requestDto.getUsername(), encryptedPassword, requestDto.getProfileImage(), UserRole.USER, UserState.ACTIVE);
+        userRepository.save(user);
+
+    }
+
+}

--- a/src/main/java/com/complete/todayspace/global/config/BcryptConfig.java
+++ b/src/main/java/com/complete/todayspace/global/config/BcryptConfig.java
@@ -1,0 +1,16 @@
+package com.complete.todayspace.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class BcryptConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/complete/todayspace/global/dto/StatusResponseDto.java
+++ b/src/main/java/com/complete/todayspace/global/dto/StatusResponseDto.java
@@ -1,16 +1,19 @@
 package com.complete.todayspace.global.dto;
 
+import com.complete.todayspace.global.entity.SuccessCode;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
 @Getter
+@JsonPropertyOrder({ "statusCode", "message" })
 public class StatusResponseDto {
 
     private Integer StatusCode;
     private String message;
 
-    public StatusResponseDto(Integer StatusCode, String message) {
-        this.StatusCode = StatusCode;
-        this.message = message;
+    public StatusResponseDto(SuccessCode successCode) {
+        this.StatusCode = successCode.getStatusCode();
+        this.message = successCode.getMessage();
     }
 
 }

--- a/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
+++ b/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
@@ -9,9 +9,9 @@ public enum ErrorCode {
 
     // Common
     FAIL(500, "실패했습니다."),
-    INVALID_REQUEST(400, "입력값을 확인해주세요.");
+    INVALID_REQUEST(400, "입력값을 확인해주세요."),
     // User
-
+    USER_NOT_UNIQUE(409, "사용 중인 아이디입니다.");
     // Products
 
     // Posts


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #1 
> Close #1 

## 📑 작업 내용
> - 조건
>   - 아이디, 비밀번호는 필수 입력
>   - 아이디는 4 ~ 20자, 알파벳 소문자 & 숫자
>   - 비밀번호는 4 ~ 20자, 알파벳 대소문자 & 숫자 & 특수문자(!@#$%^&*)
>   - DB에 중복된 username이 없다면 회원을 저장
>   - 비밀번호 암호화 후 DB 저장
>   - 클라이언트에 성공 메시지와 상태코드를 반환
> - 예외 처리
>   - 아이디, 비밀번호가 조건에 맞지 않는 경우
>   - DB에 중복된 username이 존재하는 경우

## 💭 리뷰 요구사항(선택)
>
