### PR TITLE
[2024.07.24] feat/#45-edit-post >> 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.complete.todayspace.domain.post.controller;
 
 import com.complete.todayspace.domain.post.dto.CreatePostRequestDto;
+import com.complete.todayspace.domain.post.dto.EditPostRequestDto;
 import com.complete.todayspace.domain.post.dto.PostResponseDto;
 import com.complete.todayspace.domain.post.service.PostService;
 import com.complete.todayspace.global.dto.DataResponseDto;
@@ -17,7 +18,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,5 +49,16 @@ public class PostController {
 
         DataResponseDto<Page<PostResponseDto>> post = new DataResponseDto<>(SuccessCode.POSTS_GET, responseDto);
         return new ResponseEntity<>(post, HttpStatus.OK);
+    }
+
+    @PutMapping("/posts/{postId}")
+    public ResponseEntity<StatusResponseDto> editPost(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long postId,
+            @Valid @RequestBody EditPostRequestDto requestDto
+    ) {
+        postService.editPost(userDetails.getUser().getId(), postId, requestDto);
+        StatusResponseDto responseDto = new StatusResponseDto(SuccessCode.POSTS_UPDATE);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -9,6 +9,7 @@ import com.complete.todayspace.global.dto.StatusResponseDto;
 import com.complete.todayspace.global.entity.SuccessCode;
 import com.complete.todayspace.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -54,7 +55,7 @@ public class PostController {
     @PutMapping("/posts/{postId}")
     public ResponseEntity<StatusResponseDto> editPost(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable Long postId,
+            @PathVariable @Min(1) Long postId,
             @Valid @RequestBody EditPostRequestDto requestDto
     ) {
         postService.editPost(userDetails.getUser().getId(), postId, requestDto);

--- a/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
@@ -1,0 +1,13 @@
+package com.complete.todayspace.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class EditPostRequestDto {
+
+    @NotBlank
+    @Length(max = 600)
+    private String content;
+}

--- a/src/main/java/com/complete/todayspace/domain/post/entitiy/Post.java
+++ b/src/main/java/com/complete/todayspace/domain/post/entitiy/Post.java
@@ -27,4 +27,8 @@ public class Post extends AllTimestamp {
         this.content = content;
         this.user = user;
     }
+
+    public void updatePost(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.complete.todayspace.domain.post.repository;
 
 import com.complete.todayspace.domain.post.entitiy.Post;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByOrderByUpdatedAtDesc(Pageable pageable);
 
     boolean existsByIdAndUserId(Long postId, Long userId);
+
+    Optional<Post> findByIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/complete/todayspace/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/post/repository/PostRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByOrderByUpdatedAtDesc(Pageable pageable);
+
+    boolean existsByIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
+++ b/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
@@ -1,10 +1,13 @@
 package com.complete.todayspace.domain.post.service;
 
 import com.complete.todayspace.domain.post.dto.CreatePostRequestDto;
+import com.complete.todayspace.domain.post.dto.EditPostRequestDto;
 import com.complete.todayspace.domain.post.dto.PostResponseDto;
 import com.complete.todayspace.domain.post.entitiy.Post;
 import com.complete.todayspace.domain.post.repository.PostRepository;
 import com.complete.todayspace.domain.user.entity.User;
+import com.complete.todayspace.global.exception.CustomException;
+import com.complete.todayspace.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,5 +31,22 @@ public class PostService {
     public Page<PostResponseDto> getPostPage(Pageable pageable) {
         Page<Post> postPage = postRepository.findAllByOrderByUpdatedAtDesc(pageable);
         return postPage.map(post -> new PostResponseDto(post.getId(), post.getContent(), post.getUpdatedAt()));
+    }
+
+    @Transactional
+    public void editPost(Long userId, Long postId, EditPostRequestDto requestDto) {
+        Post post = findByPost(postId);
+        if (!isPostOwner(postId, userId)) {
+            throw new CustomException(ErrorCode.NOT_OWNER_POST);
+        }
+        post.updatePost(requestDto.getContent());
+    }
+
+    private Post findByPost(Long postId) {
+        return postRepository.findById(postId).orElse(null);
+    }
+
+    private boolean isPostOwner(Long postId, Long userId) {
+        return postRepository.existsByIdAndUserId(postId, userId);
     }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
+++ b/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
@@ -23,7 +23,6 @@ public class PostService {
     @Transactional
     public void createPost(User user, CreatePostRequestDto requestDto) {
         Post savePost = new Post(requestDto.getContent(), user);
-
         postRepository.save(savePost);
     }
 
@@ -35,15 +34,9 @@ public class PostService {
 
     @Transactional
     public void editPost(Long userId, Long postId, EditPostRequestDto requestDto) {
-        Post post = findByPost(postId);
-        if (!isPostOwner(postId, userId)) {
-            throw new CustomException(ErrorCode.NOT_OWNER_POST);
-        }
+        Post post = postRepository.findByIdAndUserId(postId, userId).orElseThrow(
+                () -> new CustomException(ErrorCode.POST_NOT_FOUND));
         post.updatePost(requestDto.getContent());
-    }
-
-    private Post findByPost(Long postId) {
-        return postRepository.findById(postId).orElse(null);
     }
 
     private boolean isPostOwner(Long postId, Long userId) {

--- a/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
+++ b/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
@@ -22,8 +22,7 @@ public enum ErrorCode {
     NOT_OWNER_PRODUCT(403, "작성자만 변경할 수 있습니다."),
 
     // Posts
-    POST_NOT_FOUND(404,"해당 상품을 찾을 수 없습니다."),
-    NOT_OWNER_POST(403, "작성자만 변경할 수 있습니다."),
+    POST_NOT_FOUND(404, "해당 게시글을 찾을 수 없습니다."),
 
     // Hastags
 

--- a/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
+++ b/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     NOT_OWNER_PRODUCT(403, "작성자만 변경할 수 있습니다."),
 
     // Posts
+    POST_NOT_FOUND(404,"해당 상품을 찾을 수 없습니다."),
+    NOT_OWNER_POST(403, "작성자만 변경할 수 있습니다."),
 
     // Hastags
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #45 
> Close #45 

## 📑 작업 내용
> - 게시글 수정

## 💭 리뷰 요구사항(선택)
> 코드 리뷰 외 수정 기능을 구현하면서 의문이 들어 확인 부탁드리겠습니다.
현재 커뮤니티 페이지에 게시글이 최신순으로 5개가 표시 됩니다.
최신순의 기준을 updatedAt으로 하다보니 수정된 글이 최상단으로 올라갑니다.
createdAt을 기준으로 최신순으로 하는 것이 맞을 것 같은데 의견 궁금합니다.
createdAt이 맞는 경우 조회 관련 수정하도록하겠습니다.

