### PR TITLE
[2024.07.25] feat/#47 create/delete like post >> 게시글 좋아요 추가/삭제 기능 구현

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/like/entity/Like.java
+++ b/src/main/java/com/complete/todayspace/domain/like/entity/Like.java
@@ -5,10 +5,12 @@ import com.complete.todayspace.domain.user.entity.User;
 import com.complete.todayspace.global.entity.CreatedTimestamp;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "table_like")
 @Getter
+@NoArgsConstructor
 public class Like extends CreatedTimestamp {
 
     @Id
@@ -23,4 +25,8 @@ public class Like extends CreatedTimestamp {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    public Like(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
 }

--- a/src/main/java/com/complete/todayspace/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/like/repository/LikeRepository.java
@@ -1,7 +1,12 @@
 package com.complete.todayspace.domain.like.repository;
 
 import com.complete.todayspace.domain.like.entity.Like;
+import com.complete.todayspace.domain.post.entitiy.Post;
+import com.complete.todayspace.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Optional<Like> findByUserIdAndPostId(Long id, Long postId);
 }

--- a/src/main/java/com/complete/todayspace/domain/like/service/LikeService.java
+++ b/src/main/java/com/complete/todayspace/domain/like/service/LikeService.java
@@ -1,0 +1,43 @@
+package com.complete.todayspace.domain.like.service;
+
+import com.complete.todayspace.domain.like.entity.Like;
+import com.complete.todayspace.domain.like.repository.LikeRepository;
+import com.complete.todayspace.domain.post.entitiy.Post;
+import com.complete.todayspace.domain.post.repository.PostRepository;
+import com.complete.todayspace.domain.user.entity.User;
+import com.complete.todayspace.global.dto.StatusResponseDto;
+import com.complete.todayspace.global.entity.SuccessCode;
+import com.complete.todayspace.global.exception.CustomException;
+import com.complete.todayspace.global.exception.ErrorCode;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public ResponseEntity<StatusResponseDto> toggleLike(User user, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        Optional<Like> existingLike = likeRepository.findByUserIdAndPostId(user.getId(), postId);
+
+        if (existingLike.isPresent()) {
+            likeRepository.delete(existingLike.get());
+            return new ResponseEntity<>(new StatusResponseDto(SuccessCode.LIKES_DELETE), HttpStatus.OK);
+        } else {
+            Like like = new Like(user, post);
+            likeRepository.save(like);
+            return new ResponseEntity<>(new StatusResponseDto(SuccessCode.LIKES_CREATE), HttpStatus.CREATED);
+        }
+    }
+
+}

--- a/src/main/java/com/complete/todayspace/domain/like/service/LikeService.java
+++ b/src/main/java/com/complete/todayspace/domain/like/service/LikeService.java
@@ -24,7 +24,7 @@ public class LikeService {
     private final PostRepository postRepository;
 
     @Transactional
-    public ResponseEntity<StatusResponseDto> toggleLike(User user, Long postId) {
+    public boolean toggleLike(User user, Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
@@ -32,11 +32,11 @@ public class LikeService {
 
         if (existingLike.isPresent()) {
             likeRepository.delete(existingLike.get());
-            return new ResponseEntity<>(new StatusResponseDto(SuccessCode.LIKES_DELETE), HttpStatus.OK);
+            return false; // 좋아요 삭제
         } else {
             Like like = new Like(user, post);
             likeRepository.save(like);
-            return new ResponseEntity<>(new StatusResponseDto(SuccessCode.LIKES_CREATE), HttpStatus.CREATED);
+            return true; // 좋아요 추가
         }
     }
 

--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -81,6 +81,19 @@ public class PostController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable @Min(1) Long postId
     ) {
-        return likeService.toggleLike(userDetails.getUser(), postId);
+        boolean isLiked = likeService.toggleLike(userDetails.getUser(), postId);
+
+        StatusResponseDto response;
+        HttpStatus status;
+
+        if (isLiked) {
+            response = new StatusResponseDto(SuccessCode.LIKES_CREATE);
+            status = HttpStatus.CREATED;
+        } else {
+            response = new StatusResponseDto(SuccessCode.LIKES_DELETE);
+            status = HttpStatus.OK;
+        }
+
+        return new ResponseEntity<>(response, status);
     }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.complete.todayspace.domain.post.controller;
 
+import com.complete.todayspace.domain.like.service.LikeService;
 import com.complete.todayspace.domain.post.dto.CreatePostRequestDto;
 import com.complete.todayspace.domain.post.dto.EditPostRequestDto;
 import com.complete.todayspace.domain.post.dto.PostResponseDto;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
+    private final LikeService likeService;
 
     @PostMapping("/posts")
     public ResponseEntity<StatusResponseDto> createPost(
@@ -72,5 +74,13 @@ public class PostController {
         postService.deletePost(userDetails.getUser().getId(), postId);
         StatusResponseDto responseDto = new StatusResponseDto(SuccessCode.POSTS_DELETE);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    @PostMapping("/posts/{postId}/likes")
+    public ResponseEntity<StatusResponseDto> toggleLike(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable @Min(1) Long postId
+    ) {
+        return likeService.toggleLike(userDetails.getUser(), postId);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #47 
> Close #47 

## 📑 작업 내용
> - 게시글 좋아요 추가/삭제 기능 구현

## 💭 리뷰 요구사항(선택)
> /posts/{postId}/likes  동일한 post 엔드포인트로 Like 테이블 내의 값의 여부를 판단하여 추가/삭제하도록 하였습니다.
