### PR TITLE
[2024.07.29] feat/#86 edit post image >>게시글 수정(기존 이미지 삭제, 추가)

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/common/S3Provider.java
+++ b/src/main/java/com/complete/todayspace/domain/common/S3Provider.java
@@ -2,6 +2,7 @@ package com.complete.todayspace.domain.common;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.complete.todayspace.global.exception.CustomException;
@@ -50,6 +51,10 @@ public class S3Provider {
         });
 
         return fileNameList;
+    }
+
+    public void deleteFile(String filePath) {
+        s3Client.deleteObject(new DeleteObjectRequest(bucket, filePath));
     }
 
     private String createFileName(String fileName) {

--- a/src/main/java/com/complete/todayspace/domain/common/S3Provider.java
+++ b/src/main/java/com/complete/todayspace/domain/common/S3Provider.java
@@ -21,8 +21,14 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 public class S3Provider {
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
+
+    // S3 base URL 추가
+    @Value("${cloud.aws.s3.base-url}")
+    private String s3BaseUrl;
+
     private final AmazonS3 s3Client;
 
     public void createFolder(String folderName) {
@@ -47,7 +53,8 @@ public class S3Provider {
                 throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
             }
 
-            fileNameList.add(folderName + "/" + fileName);
+            String fileUrl = s3Client.getUrl(bucket, folderName + "/" + fileName).toString();
+            fileNameList.add(fileUrl);
         });
 
         return fileNameList;
@@ -77,5 +84,10 @@ public class S3Provider {
             throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
         }
         return fileName.substring(fileName.lastIndexOf("."));
+    }
+
+    // S3 URL 반환하는 메소드 추가
+    public String getS3Url(String filePath) {
+        return s3BaseUrl + filePath;
     }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -97,7 +97,13 @@ public class PostController {
             @RequestPart("data") @Valid EditPostRequestDto requestDto,
             @RequestPart(value = "files", required = false) List<MultipartFile> newImages
     ) {
-        requestDto.setNewImages(newImages);
+        // 새로운 상태로 DTO 생성
+        EditPostRequestDto updatedRequestDto = new EditPostRequestDto(
+                requestDto.getContent(),
+                requestDto.getDeleteImageIds(),
+                newImages
+        );
+
         postService.editPost(userDetails.getUser().getId(), postId, requestDto);
         StatusResponseDto responseDto = new StatusResponseDto(SuccessCode.POSTS_UPDATE);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);

--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -94,8 +94,10 @@ public class PostController {
     public ResponseEntity<StatusResponseDto> editPost(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable @Min(1) Long postId,
-            @Valid @RequestBody EditPostRequestDto requestDto
+            @RequestPart("data") @Valid EditPostRequestDto requestDto,
+            @RequestPart(value = "files", required = false) List<MultipartFile> newImages
     ) {
+        requestDto.setNewImages(newImages);
         postService.editPost(userDetails.getUser().getId(), postId, requestDto);
         StatusResponseDto responseDto = new StatusResponseDto(SuccessCode.POSTS_UPDATE);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);

--- a/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
@@ -1,13 +1,21 @@
 package com.complete.todayspace.domain.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 public class EditPostRequestDto {
 
     @NotBlank
     @Length(max = 600)
     private String content;
+
+    private List<Long> deleteImageIds;
+
+    private List<MultipartFile> newImages;
 }

--- a/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
@@ -18,4 +18,10 @@ public class EditPostRequestDto {
     private List<Long> deleteImageIds;
 
     private List<MultipartFile> newImages;
+
+    public EditPostRequestDto(String content, List<Long> deleteImageIds, List<MultipartFile> newImages) {
+        this.content = content;
+        this.deleteImageIds = deleteImageIds;
+        this.newImages = newImages;
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #86 
> Close #86 

## 📑 작업 내용
> - 게시글 수정 시 기존 이미지 삭제, 추가 기능 구현

## 💭 리뷰 요구사항(선택)
> 
Postman 테스트 시, 등록 시와 같은 절차로 이미지 업로드 시 >> 이미지 추가 됨
아래와 같이 Json data 로 이미지 아이디 입력 시 >> 기존 이미지 삭제 됨
{"content": "수정된 글","deleteImageIds": [imageId]}

기능은 정상적으로 작동합니다. 다만, 백엔드 상에서 위와 같이 처라하는 것이 맞는지 검토를 요청드립니다.
