### PR TITLE
[2024.07.30] feat/#89 get posts hashtag >> 게시글 조회(해시태그 포함)

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/hashtag/dto/HashtagDto.java
+++ b/src/main/java/com/complete/todayspace/domain/hashtag/dto/HashtagDto.java
@@ -1,0 +1,12 @@
+package com.complete.todayspace.domain.hashtag.dto;
+
+import lombok.Getter;
+
+@Getter
+public class HashtagDto {
+    private final String hashtagName;
+
+    public HashtagDto(String hashtagName) {
+        this.hashtagName = hashtagName;
+    }
+}

--- a/src/main/java/com/complete/todayspace/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/complete/todayspace/domain/hashtag/entity/Hashtag.java
@@ -4,10 +4,12 @@ import com.complete.todayspace.domain.post.entitiy.Post;
 import com.complete.todayspace.global.entity.CreatedTimestamp;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "table_hashtag")
 @Getter
+@NoArgsConstructor
 public class Hashtag extends CreatedTimestamp {
 
     @Id

--- a/src/main/java/com/complete/todayspace/domain/hashtag/entity/HashtagList.java
+++ b/src/main/java/com/complete/todayspace/domain/hashtag/entity/HashtagList.java
@@ -3,10 +3,12 @@ package com.complete.todayspace.domain.hashtag.entity;
 import com.complete.todayspace.global.entity.CreatedTimestamp;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "table_hashtag_list")
 @Getter
+@NoArgsConstructor
 public class HashtagList extends CreatedTimestamp {
 
     @Id

--- a/src/main/java/com/complete/todayspace/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/hashtag/repository/HashtagRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     List<Hashtag> findByPostId(Long postId);
     List<Hashtag> findTop5ByHashtagListOrderByPostUpdatedAtDesc(HashtagList hashtagList);
+
+    List<Hashtag> findByHashtagList(HashtagList hashtagList);
 }

--- a/src/main/java/com/complete/todayspace/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/hashtag/repository/HashtagRepository.java
@@ -1,9 +1,11 @@
 package com.complete.todayspace.domain.hashtag.repository;
 
 import com.complete.todayspace.domain.hashtag.entity.Hashtag;
+import com.complete.todayspace.domain.hashtag.entity.HashtagList;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     List<Hashtag> findByPostId(Long postId);
+    List<Hashtag> findTop5ByHashtagListOrderByPostUpdatedAtDesc(HashtagList hashtagList);
 }

--- a/src/main/java/com/complete/todayspace/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/hashtag/repository/HashtagRepository.java
@@ -1,7 +1,9 @@
 package com.complete.todayspace.domain.hashtag.repository;
 
 import com.complete.todayspace.domain.hashtag.entity.Hashtag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+    List<Hashtag> findByPostId(Long postId);
 }

--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -91,6 +91,12 @@ public class PostController {
         return new ResponseEntity<>(post, HttpStatus.OK);
     }
 
+    @GetMapping("/hashtags")
+    public ResponseEntity<?> getPostsByHashtag(@RequestParam("hashtagsName") List<String> hashtagsName) {
+        List<PostResponseDto> posts = postService.getPostsByHashtags(hashtagsName);
+        return ResponseEntity.ok(new DataResponseDto<>(SuccessCode.POSTS_GET, posts));
+    }
+
     @PutMapping("/posts/{postId}")
     public ResponseEntity<StatusResponseDto> editPost(
             @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.complete.todayspace.domain.post.controller;
 
+import static com.complete.todayspace.domain.hashtag.entity.QHashtag.hashtag;
+
 import com.complete.todayspace.domain.comment.dto.CommentResponseDto;
 import com.complete.todayspace.domain.comment.dto.CreateCommentRequestDto;
 import com.complete.todayspace.domain.comment.service.CommentService;
@@ -70,7 +72,8 @@ public class PostController {
     public ResponseEntity<DataResponseDto<Page<PostResponseDto>>> getPostPage(
             @RequestParam(defaultValue = "1") String page,
             @RequestParam(defaultValue = "updatedAt") String sortBy,
-            @RequestParam(defaultValue = "DESC") String direction) {
+            @RequestParam(defaultValue = "DESC") String direction,
+            @RequestParam(required = false) String hashtag) {
 
         int pageNumber;
         try {
@@ -85,17 +88,17 @@ public class PostController {
         Sort sort = Sort.by(direction.equalsIgnoreCase("ASC") ? Sort.Direction.ASC : Sort.Direction.DESC, sortBy);
         Pageable pageable = PageRequest.of(pageNumber - 1, 5, sort);
 
-        Page<PostResponseDto> responseDto = postService.getPostPage(pageable);
-        DataResponseDto<Page<PostResponseDto>> post = new DataResponseDto<>(SuccessCode.POSTS_GET, responseDto);
+        Page<PostResponseDto> responseDto;
+        if (hashtag != null && !hashtag.trim().isEmpty()) {
+            responseDto = postService.getPostsByHashtag(hashtag, pageable);
+        } else {
+            responseDto = postService.getPostPage(pageable);
+        }
 
+        DataResponseDto<Page<PostResponseDto>> post = new DataResponseDto<>(SuccessCode.POSTS_GET, responseDto);
         return new ResponseEntity<>(post, HttpStatus.OK);
     }
 
-    @GetMapping("/hashtags")
-    public ResponseEntity<?> getPostsByHashtag(@RequestParam("hashtagsName") List<String> hashtagsName) {
-        List<PostResponseDto> posts = postService.getPostsByHashtags(hashtagsName);
-        return ResponseEntity.ok(new DataResponseDto<>(SuccessCode.POSTS_GET, posts));
-    }
 
     @PutMapping("/posts/{postId}")
     public ResponseEntity<StatusResponseDto> editPost(

--- a/src/main/java/com/complete/todayspace/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.complete.todayspace.domain.post.dto;
 
+import com.complete.todayspace.domain.hashtag.dto.HashtagDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
@@ -11,11 +12,13 @@ public class PostResponseDto {
     private final String content;
     private final LocalDateTime updatedAt;
     private final List<PostImageDto> images;
+    private final List<HashtagDto> hashtags;
 
-    public PostResponseDto(Long id, String content, LocalDateTime updatedAt, List<PostImageDto> images) {
+    public PostResponseDto(Long id, String content, LocalDateTime updatedAt, List<PostImageDto> images, List<HashtagDto> hashtags) {
         this.id = id;
         this.content = content;
         this.updatedAt = updatedAt;
         this.images = images;
+        this.hashtags = hashtags;
     }
 }

--- a/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
+++ b/src/main/java/com/complete/todayspace/global/exception/ErrorCode.java
@@ -13,15 +13,19 @@ public enum ErrorCode {
     INVALID_URL_ACCESS(400, "잘못된 URL 접근입니다."),
     UNAUTHENTICATED(401, "로그인 후 이용해주세요."),
     UNAUTHORIZED_ADMIN(403, "권한이 없는 사용자입니다."),
+
     // User
     USER_NOT_UNIQUE(409, "사용 중인 아이디입니다."),
     CHECK_USERNAME_PASSWORD(400, "아이디, 비밀번호를 확인해주세요."),
     USER_NOT_FOUND(400, "해당 유저를 찾을 수 없습니다."),
+
     // Products
     PRODUCT_NOT_FOUND(404, "해당 상품을 찾을 수 없습니다."),
     NOT_OWNER_PRODUCT(403, "작성자만 변경할 수 있습니다."),
+
     //Review
     DUPLICATE_REVIEW(409, "이미 작성된 후기글이 있습니다."),
+
     //Wish
     DUPLICATE_WISH(409, "이미 찜한 상품입니다."),
     CANNOT_ADD_WISH(400, "본인 상품에는 찜 할 수 없습니다."),
@@ -32,7 +36,9 @@ public enum ErrorCode {
     POST_NOT_FOUND(404, "해당 게시글을 찾을 수 없습니다."),
     FILE_UPLOAD_ERROR(400, "이미지 파일을 확인해주세요."),
     NO_REPRESENTATIVE_IMAGE_FOUND(404, "대표 이미지가 없습니다."),
+
     // Hastags
+    HASHTAG_NOT_FOUND(400, "해시태그를 찾을 수 없습니다."),
 
     // Chats
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #89 
> Close #89 

## 📑 작업 내용
> 
- 게시글 조회(해시태그 포함)
- 해시태그별 최신 5개 글 조회

## 💭 리뷰 요구사항(선택)
> url 에 해시태그 입력하여 확인 가능합니다.
예) http://localhost:8080/v1/hashtags?hashtagsName=해시태그4,해시태그1
:: 해시태그4와 해시태그1이 포함된 게시물 모두 조회
