### PR TITLE
[2024.08.02] feat/#126 post get >> 게시글 단건 조회 추가

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -91,6 +91,16 @@ public class PostController {
         return new ResponseEntity<>(post, HttpStatus.OK);
     }
 
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<DataResponseDto<PostResponseDto>> getPost(
+        @Min(1) @PathVariable Long postId
+    ) {
+        PostResponseDto responseDto = postService.getPost(postId);
+
+        DataResponseDto<PostResponseDto> response = new DataResponseDto<>(SuccessCode.POSTS_GET, responseDto);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
 
     @PutMapping("/posts/{postId}")
     public ResponseEntity<StatusResponseDto> editPost(

--- a/src/main/java/com/complete/todayspace/domain/post/dto/PostImageDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/PostImageDto.java
@@ -6,12 +6,16 @@ import lombok.Getter;
 public class PostImageDto {
 
     private final Long id;
-    private final String imagePath;
+    private String imagePath;
     private final Long imageOrder;
 
     public PostImageDto(Long id, Long imageOrder, String imagePath) {
         this.id = id;
         this.imageOrder = imageOrder;
+        this.imagePath = imagePath;
+    }
+
+    public void update(String imagePath) {
         this.imagePath = imagePath;
     }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/PostResponseDto.java
@@ -11,7 +11,7 @@ public class PostResponseDto {
     private final Long id;
     private final String content;
     private final LocalDateTime updatedAt;
-    private final List<PostImageDto> images;
+    private List<PostImageDto> images;
     private final List<HashtagDto> hashtags;
     private final long likeCount;
 
@@ -22,5 +22,9 @@ public class PostResponseDto {
         this.images = images;
         this.hashtags = hashtags;
         this.likeCount = likeCount;
+    }
+
+    public void update(List<PostImageDto> images) {
+        this.images = images;
     }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/entitiy/Post.java
+++ b/src/main/java/com/complete/todayspace/domain/post/entitiy/Post.java
@@ -1,8 +1,11 @@
 package com.complete.todayspace.domain.post.entitiy;
 
+import com.complete.todayspace.domain.product.entity.ImageProduct;
 import com.complete.todayspace.domain.user.entity.User;
 import com.complete.todayspace.global.entity.AllTimestamp;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +25,9 @@ public class Post extends AllTimestamp {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "post", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    private List<ImagePost> imagePosts = new ArrayList<>();
 
     public Post(String content, User user) {
         this.content = content;

--- a/src/main/java/com/complete/todayspace/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/complete/todayspace/domain/post/repository/PostRepository.java
@@ -1,12 +1,16 @@
 package com.complete.todayspace.domain.post.repository;
 
+import com.complete.todayspace.domain.post.dto.PostMainResponseDto;
+import com.complete.todayspace.domain.post.dto.PostResponseDto;
 import com.complete.todayspace.domain.post.entitiy.Post;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>,
+    QuerydslPredicateExecutor<PostResponseDto>, PostRepositoryQuery{
 
     Page<Post> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 

--- a/src/main/java/com/complete/todayspace/domain/post/repository/PostRepositoryQuery.java
+++ b/src/main/java/com/complete/todayspace/domain/post/repository/PostRepositoryQuery.java
@@ -1,0 +1,9 @@
+package com.complete.todayspace.domain.post.repository;
+
+import com.complete.todayspace.domain.post.dto.PostResponseDto;
+
+public interface PostRepositoryQuery {
+
+    public PostResponseDto findPostById(Long postId);
+
+}

--- a/src/main/java/com/complete/todayspace/domain/post/repository/PostRepositoryQueryImpl.java
+++ b/src/main/java/com/complete/todayspace/domain/post/repository/PostRepositoryQueryImpl.java
@@ -1,0 +1,60 @@
+package com.complete.todayspace.domain.post.repository;
+
+import static com.complete.todayspace.domain.hashtag.entity.QHashtag.hashtag;
+import static com.complete.todayspace.domain.hashtag.entity.QHashtagList.hashtagList;
+import static com.complete.todayspace.domain.like.entity.QLike.like;
+import static com.complete.todayspace.domain.post.entitiy.QImagePost.imagePost;
+import static com.complete.todayspace.domain.post.entitiy.QPost.post;
+
+import com.complete.todayspace.domain.common.S3Provider;
+import com.complete.todayspace.domain.hashtag.dto.HashtagDto;
+import com.complete.todayspace.domain.post.dto.PostImageDto;
+import com.complete.todayspace.domain.post.dto.PostResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PostRepositoryQueryImpl implements PostRepositoryQuery{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final S3Provider s3Provider;
+
+    @Override
+    public PostResponseDto findPostById(Long postId) {
+        PostResponseDto postQuery = jpaQueryFactory
+            .select(Projections.constructor(PostResponseDto.class,
+                post.id,
+                post.content,
+                post.updatedAt,
+                Projections.list(Projections.constructor(PostImageDto.class,
+                    imagePost.id,
+                    imagePost.orders,
+                    imagePost.filePath
+                )),
+                Projections.list(Projections.constructor(HashtagDto.class,
+                    hashtagList.hashtagName
+                )),
+                like.count()
+            ))
+            .from(post)
+            .leftJoin(imagePost).on(imagePost.post.id.eq(post.id))
+            .leftJoin(hashtag).on(hashtag.post.id.eq(post.id))
+            .leftJoin(hashtagList).on(hashtag.hashtagList.id.eq(hashtagList.id)) // Make sure to join hashtagList
+            .leftJoin(like).on(like.post.id.eq(post.id))
+            .where(post.id.eq(postId))
+            .groupBy(post.id, imagePost.id, hashtagList.hashtagName) // GROUP BY 절 추가
+            .fetchOne();
+
+        // PostImageDto의 S3 URL 변환
+        if (postQuery != null && postQuery.getImages() != null) {
+            List<PostImageDto> updatedImages = postQuery.getImages().stream()
+                .peek(imageDto -> imageDto.update(s3Provider.getS3Url(imageDto.getImagePath()))).collect(Collectors.toList());
+            postQuery.update(updatedImages);
+        }
+
+        return postQuery;
+    }
+}

--- a/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
+++ b/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
@@ -234,4 +234,9 @@ public class PostService {
             return new PostResponseDto(post.getId(), post.getContent(), post.getUpdatedAt(), imageDtos, hashtagDtos, likeCount);
         });
     }
+
+    @Transactional(readOnly = true)
+    public PostResponseDto getPost(Long postId) {
+        return null;
+    }
 }

--- a/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
+++ b/src/main/java/com/complete/todayspace/domain/post/service/PostService.java
@@ -237,6 +237,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostResponseDto getPost(Long postId) {
-        return null;
+
+        return postRepository.findPostById(postId);
     }
 }

--- a/src/main/java/com/complete/todayspace/global/config/SecurityConfig.java
+++ b/src/main/java/com/complete/todayspace/global/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                         .requestMatchers("/v1/auth/signup", "/v1/auth/refresh", "/v1/auth/check").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/v1/products", "/v1/products**", "/v1/products/*",
-                                "/v1/posts", "/v1/posts/hashtags**",
+                                "/v1/posts", "/v1/posts/*", "/v1/posts/hashtags**",
                                 "/v1/kakao/callback", "/v1/naver/callback", "/v1/google/callback").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling( (exceptionHandling) -> {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #126 
> Close #126

## 📑 작업 내용
> - 게시글 단건 조회 api 추가
> - 게시글 단건 조회 QueryDSL 추가

## 💭 리뷰 요구사항(선택)
> - 현재 쿼리 조회 이후 Dto에서 이미지 주소에 s3 url을 추가하기 위해 update 함수를 만들어놨는데 이 부분을 추후에 dto 자체에서 쿼리 조회로 받으면서 s3 provider을 사용해서 넣어주어야 할지 아니면 다른 방법으로 넣어줘야 할지 고민해볼 필요성이 있다고 판단했습니다.
-> 함께 어떤 방식이 좋을지 고민해주세요!
