### PR TITLE
[2024.08.02] refactor/#129-post >> 게시글 단건 조회 사용자 정보 추가

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/PostResponseDto.java
@@ -13,7 +13,7 @@ public class PostResponseDto {
     private List<PostImageDto> images;
     private final List<HashtagDto> hashtags;
     private final long likeCount;
-    private final String profileImage;
+    private String profileImage;
     private final String nickname;
 
     public PostResponseDto(Long id, String content, LocalDateTime updatedAt, List<PostImageDto> images, List<HashtagDto> hashtags, long likeCount, String profileImage, String nickname) {
@@ -30,4 +30,9 @@ public class PostResponseDto {
     public void update(List<PostImageDto> images) {
         this.images = images;
     }
+
+    public void updateProfile(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
 }

--- a/src/main/java/com/complete/todayspace/domain/post/repository/PostRepositoryQueryImpl.java
+++ b/src/main/java/com/complete/todayspace/domain/post/repository/PostRepositoryQueryImpl.java
@@ -5,6 +5,7 @@ import static com.complete.todayspace.domain.hashtag.entity.QHashtagList.hashtag
 import static com.complete.todayspace.domain.like.entity.QLike.like;
 import static com.complete.todayspace.domain.post.entitiy.QImagePost.imagePost;
 import static com.complete.todayspace.domain.post.entitiy.QPost.post;
+import static com.complete.todayspace.domain.user.entity.QUser.user;
 
 import com.complete.todayspace.domain.common.S3Provider;
 import com.complete.todayspace.domain.hashtag.dto.HashtagDto;
@@ -37,22 +38,32 @@ public class PostRepositoryQueryImpl implements PostRepositoryQuery{
                 Projections.list(Projections.constructor(HashtagDto.class,
                     hashtagList.hashtagName
                 )),
-                like.count()
+                like.count(),
+                user.profileImage,
+                user.username
             ))
             .from(post)
             .leftJoin(imagePost).on(imagePost.post.id.eq(post.id))
             .leftJoin(hashtag).on(hashtag.post.id.eq(post.id))
             .leftJoin(hashtagList).on(hashtag.hashtagList.id.eq(hashtagList.id)) // Make sure to join hashtagList
             .leftJoin(like).on(like.post.id.eq(post.id))
+            .leftJoin(user).on(user.id.eq(post.user.id))
             .where(post.id.eq(postId))
-            .groupBy(post.id, imagePost.id, hashtagList.hashtagName) // GROUP BY 절 추가
+            .groupBy(post.id, imagePost.id, hashtagList.hashtagName, user.id) // GROUP BY 절 추가
             .fetchOne();
 
         // PostImageDto의 S3 URL 변환
-        if (postQuery != null && postQuery.getImages() != null) {
-            List<PostImageDto> updatedImages = postQuery.getImages().stream()
-                .peek(imageDto -> imageDto.update(s3Provider.getS3Url(imageDto.getImagePath()))).collect(Collectors.toList());
-            postQuery.update(updatedImages);
+        if (postQuery != null) {
+            if (postQuery.getImages() != null) {
+                List<PostImageDto> updatedImages = postQuery.getImages().stream()
+                    .peek(imageDto -> imageDto.update(s3Provider.getS3Url(imageDto.getImagePath())))
+                    .collect(Collectors.toList());
+                postQuery.update(updatedImages);
+            }
+            if (postQuery.getProfileImage() != null) {
+                 String updatedImages = s3Provider.getS3Url(postQuery.getProfileImage());
+                postQuery.updateProfile(updatedImages);
+            }
         }
 
         return postQuery;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #129 
> Close #129

## 📑 작업 내용
> - 게시글 단건 조회 사용자 정보 추가

## 💭 리뷰 요구사항(선택)
> - 여기도 queryDSL로 받아온 후 이미지의 prefix를 추가하면서 dto에 update 부분이 추가되었습니다.
