### PR TITLE
[2024.08.07] fix/#146-post-hashtag >>  게시글 해시태그 수정, 삭제 문제 개선

### DIFF
--- a/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
+++ b/src/main/java/com/complete/todayspace/domain/post/controller/PostController.java
@@ -122,7 +122,8 @@ public class PostController {
                 requestDto.getContent(),
                 requestDto.getDeleteImageIds(),
                 newImages,
-                requestDto.getHashtags()
+                requestDto.getHashtags(),
+                requestDto.getDeleteHashtags() // 삭제할 해시태그 목록 추가
         );
 
         postService.editPost(userDetails.getUser().getId(), postId, updatedRequestDto);

--- a/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
+++ b/src/main/java/com/complete/todayspace/domain/post/dto/EditPostRequestDto.java
@@ -19,10 +19,11 @@ public class EditPostRequestDto {
     private List<String> hashtags;
     private List<String> deleteHashtags;
 
-    public EditPostRequestDto(String content, List<Long> deleteImageIds, List<MultipartFile> newImages,List<String> hashtags) {
+    public EditPostRequestDto(String content, List<Long> deleteImageIds, List<MultipartFile> newImages, List<String> hashtags, List<String> deleteHashtags) {
         this.content = content;
         this.deleteImageIds = deleteImageIds;
         this.newImages = newImages;
         this.hashtags = hashtags;
+        this.deleteHashtags = deleteHashtags;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #146 
> Close #146 

## 📑 작업 내용
> - 게시글 해시태그 수정, 삭제 문제 개선

## 💭 리뷰 요구사항(선택)
>
