### PR TITLE
[2024.09.20] refactor/code >> ExecutionTime 엔티티 및 실행 시간 저장 서비스 추가

### DIFF
--- a/src/main/java/com/complete/todayspace/global/aop/TimeTrackerAop.java
+++ b/src/main/java/com/complete/todayspace/global/aop/TimeTrackerAop.java
@@ -1,5 +1,7 @@
 package com.complete.todayspace.global.aop;
 
+import com.complete.todayspace.global.tracking.service.ExecutionTimeService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -9,7 +11,10 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class TimeTrackerAop {
+
+    private final ExecutionTimeService executionTimeService;
 
     @Around("execution(* com.complete.todayspace.domain.chat.service.ChatRoomService.getChatRoom(..)) || " +
             "execution(* com.complete.todayspace.domain.product.service.ProductService.getResponseDto(..)) || " +
@@ -18,16 +23,19 @@ public class TimeTrackerAop {
             "execution(* com.complete.todayspace.domain.review.service.ReviewService.getMyReview(..)) ||" +
             "execution(* com.complete.todayspace.domain.review.service.ReviewService.getReviewByUsername(..)) ||" +
             "execution(* com.complete.todayspace.domain.wish.service.WishService.getMyWishList(..))")
-    public Object checkTime(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object logAndSaveExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
 
-        long startTime = System.currentTimeMillis();
+        Long startTime = System.currentTimeMillis();
 
         Object proceed = joinPoint.proceed();
 
-        long endTime = System.currentTimeMillis();
-        long executionTime = endTime - startTime;
+        Long endTime = System.currentTimeMillis();
+        Long executionTime = endTime - startTime;
 
-        log.info("Method execution location: " + joinPoint.getSignature() + ", Execution time: " + executionTime + "ms");
+        String joinPointSignature = joinPoint.getSignature().toString();
+        executionTimeService.saveExecutionTime(joinPointSignature, executionTime);
+
+        log.info("Method execution location: " + joinPointSignature + ", Execution time: " + executionTime + "ms");
 
         return proceed;
     }

--- a/src/main/java/com/complete/todayspace/global/tracking/entity/ExecutionTime.java
+++ b/src/main/java/com/complete/todayspace/global/tracking/entity/ExecutionTime.java
@@ -1,0 +1,28 @@
+package com.complete.todayspace.global.tracking.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "table_execution_time")
+@Getter
+@NoArgsConstructor
+public class ExecutionTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String methodName;
+
+    @Column
+    private Long time;
+
+    public ExecutionTime(String methodName, Long time) {
+        this.methodName = methodName;
+        this.time = time;
+    }
+
+}

--- a/src/main/java/com/complete/todayspace/global/tracking/repository/ExecutionTimeRepository.java
+++ b/src/main/java/com/complete/todayspace/global/tracking/repository/ExecutionTimeRepository.java
@@ -1,0 +1,7 @@
+package com.complete.todayspace.global.tracking.repository;
+
+import com.complete.todayspace.global.tracking.entity.ExecutionTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExecutionTimeRepository extends JpaRepository<ExecutionTime, Long> {
+}

--- a/src/main/java/com/complete/todayspace/global/tracking/service/ExecutionTimeService.java
+++ b/src/main/java/com/complete/todayspace/global/tracking/service/ExecutionTimeService.java
@@ -1,0 +1,28 @@
+package com.complete.todayspace.global.tracking.service;
+
+import com.complete.todayspace.global.tracking.entity.ExecutionTime;
+import com.complete.todayspace.global.tracking.repository.ExecutionTimeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExecutionTimeService {
+
+    private final ExecutionTimeRepository executionTimeRepository;
+
+    private static final String PACKAGE = "com.complete.todayspace.domain.";
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveExecutionTime(String joinPointSignature, Long time) {
+
+        String methodName = joinPointSignature.substring(joinPointSignature.indexOf(" ") + 1)
+                .replaceFirst(PACKAGE, "");
+        ExecutionTime executionTime = new ExecutionTime(methodName, time);
+        executionTimeRepository.save(executionTime);
+
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
> Close #이슈번호

## 📑 작업 내용
> - 메서드 실행 시간 저장을 위한 ExecutionTime 엔티티 및 서비스 로직 추가
> - AOP에서 서비스 로직을 호출하여 DB에 저장
> - 변경된 AOP 로직에 따른 메서드명을 checkTime에서 logAndSaveExecutionTime로 변경

## 💭 리뷰 요구사항(선택)
>
